### PR TITLE
Cleanup mariadb mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,7 @@ services:
      image: mariadb:latest
      restart: always
      volumes:
-      - ./mariadb/init.sql:/docker-entrypoint-initdb.d/init.sql
-      - ./mariadb/init_data:/docker-entrypoint-initdb.d/init_data
+      - ./mariadb/:/docker-entrypoint-initdb.d/
      ports:
        - 8084:3306
      environment:


### PR DESCRIPTION
Med denna commit läses alla sql-filer in som ligger i mariadb. Detta gör att vi kan dela upp sql-koden om vi önskar. Mappen init_data blir också mountad och allt fungerar som förut.