### PR TITLE
Add post bikes from brain

### DIFF
--- a/bikeBrain/bikeBrain.py
+++ b/bikeBrain/bikeBrain.py
@@ -9,9 +9,11 @@ import json
 class Brain:
     """Class for bike brain"""
 
-    def __init__(self, _id, session, start_time, position, battery_capacity):
+    def __init__(
+        self, breaking_seed, session, token, start_time, position, battery_capacity
+    ):
         """Init"""
-        self._id = _id
+        self._id = None
         self._session = session
         self._start_time = start_time
         self._position = position
@@ -38,11 +40,17 @@ class Brain:
 
         self._current_user = None
 
-        seed(self._id)
+        self._token = token
+
+        seed(breaking_seed)
 
     def get_id(self):
         """Gets _id"""
         return self._id
+
+    def set_id(self, _id):
+        """Gets _id"""
+        self._id = _id
 
     def get_is_locked(self):
         """Gets is locked status"""
@@ -220,7 +228,7 @@ class Brain:
             self.set_start_time(time.time())
 
             position = self.get_position()
-
+            # Header med self._token
             payload = {"position": position}
 
             async with self._session.put(

--- a/bikeBrain/docker-compose.yml
+++ b/bikeBrain/docker-compose.yml
@@ -6,18 +6,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.bike
-    depends_on:
-      - "server"
     working_dir: /brain/app
     command: python3 main.py
-
-  server:
-    container_name: server
-    build:
-      context: .
-      dockerfile: ./Dockerfile.server
-    working_dir: /server/app
-    command: node server.js
-    ports:
-      - 5000:3000
-    restart: on-failure
+    networks:
+      - vteam_default

--- a/bikeBrain/docker-compose.yml
+++ b/bikeBrain/docker-compose.yml
@@ -6,7 +6,18 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.bike
+    depends_on:
+      - "server"
     working_dir: /brain/app
     command: python3 main.py
-    networks:
-      - vteam_default
+
+  server:
+    container_name: server
+    build:
+      context: .
+      dockerfile: ./Dockerfile.server
+    working_dir: /server/app
+    command: node server.js
+    ports:
+      - 5000:3000
+    restart: on-failure

--- a/bikeBrain/main.py
+++ b/bikeBrain/main.py
@@ -21,7 +21,7 @@ async def main():
         report_dict = {}
         users = []
         bikes = []
-        bikes_start_positions = []
+        # bikes_start_positions = []
         start_time = time.time()
         report_start_time = time.time()
         report_interval = 5
@@ -67,7 +67,7 @@ async def main():
             longitude = coordinates[1]
 
             # create header with admin token
-            headers = {f"Authorization: `Bearer {token}`,"}
+            headers = {"Authorization": "Bearer {token}"}
             payload = {"latitude": latitude, "longitude": longitude}
 
             response = requests.post(
@@ -76,36 +76,18 @@ async def main():
 
             # Get the new bike id and token
             json_response = response.json()
-            _id = json_response.data.id
-            bike_token = json_response.data.token
+            print(json_response)
+            _id = json_response["data"]["id"]
+            bike_token = json_response["data"]["token"]
 
             # Get the new bike
             response = requests.get(f"http://admin-api:3000/v1/bikes/{_id}")
 
-            bike_properties = response.json()
-
-            # Create the position, with bike_properties add the coordinates
-            """  position = {
-                "type": "Feature",
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": coordinates,
-                },
-                "properties": {
-                    "whole": True,
-                    "charging": False,
-                    "blocked": False,
-                    "batterywarning": False,
-                    "batterydepleted": False,
-                    "rented": True,
-                    "userid": None,
-                    "featureType": "bikes",
-                },
-            } """
+            position = response.json()["data"]
 
             # Create bike
-            bikes[i] = bikeBrain.Brain(
-                i + 1, session, bike_token, start_time, position, 100
+            bikes.append(
+                bikeBrain.Brain(_id, session, bike_token, start_time, position)
             )
 
             # Request på cykel med id, skapa cykeln och lägg i lista

--- a/bikeBrain/main.py
+++ b/bikeBrain/main.py
@@ -66,7 +66,7 @@ async def main():
             latitude = coordinates[0]
             longitude = coordinates[1]
 
-            # create header med admin token
+            # create header with admin token
             headers = {f"Authorization: `Bearer {token}`,"}
             payload = {"latitude": latitude, "longitude": longitude}
 
@@ -105,14 +105,14 @@ async def main():
 
             # Create bike
             bikes[i] = bikeBrain.Brain(
-                i + 1, session, start_time, bikes_start_positions[i], 100
+                i + 1, session, bike_token, start_time, position, 100
             )
 
             # Request på cykel med id, skapa cykeln och lägg i lista
             # bikes[i].set_id(r.data.id)
             # bikes[i].set_token(r.data.token)
 
-            bikes_start_positions.append(position)
+            # bikes_start_positions.append()
 
         # Create users and append them to the user list,
         # users get id:s from 1 -

--- a/bikeBrain/main.py
+++ b/bikeBrain/main.py
@@ -16,8 +16,8 @@ async def main():
     token = "asdf"
 
     async with aiohttp.ClientSession() as session:
-        nr_of_users = 1
-        nr_of_bikes = 1
+        nr_of_users = 72
+        nr_of_bikes = 5000
         report_dict = {}
         users = []
         bikes = []
@@ -60,7 +60,9 @@ async def main():
         for i in range(nr_of_bikes):
             # Get the coordinates for the starting point
             # from the travel_plans list
-            coordinates = travel_plans[i][0]
+            coordinates = [16.0, 59.0]
+            if i < len(travel_plans):
+                coordinates = travel_plans[i][0]
 
             # Post bike to db
             latitude = coordinates[0]
@@ -83,7 +85,9 @@ async def main():
             # Get the new bike
             response = requests.get(f"http://admin-api:3000/v1/bikes/{_id}")
 
-            position = response.json()["data"]
+            position = response.json()["data"][0]["position"]
+
+            print(position)
 
             # Create bike
             bikes.append(
@@ -101,12 +105,14 @@ async def main():
         for i in range(nr_of_users):
             users.append(UserClass.User(i + 1, bikes[i], travel_plans[i]))
 
+        print(users)
+
         # Decides if program loop runs
-        run = False
+        run = True
 
         # Loop through users and begin journeys (unlock bikes)
-        # for user in users:
-        # user.begin_journey()
+        for user in users:
+            user.begin_journey()
 
         while run:
             try:

--- a/bikeBrain/user.py
+++ b/bikeBrain/user.py
@@ -33,6 +33,7 @@ class User:
     def begin_journey(self):
         """Begins journey"""
         self.bike.unlock(self._id)
+        print(self.bike.get_current_user())
         self.set_journey_start_time(time.time())
         self.bike.set_speed(15)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,3 +81,14 @@ services:
     ports:
       - 3100:3000
     restart: on-failure
+
+  bike-brain:
+    container_name: bike-brain2
+    build:
+      context: ./bikeBrain
+      dockerfile: ./Dockerfile.bike
+    working_dir: /brain/app
+    command: python3 main.py
+    depends_on:
+      - "admin-api"
+      - "mariadb"


### PR DESCRIPTION
This PR adds the bikeBrain to the project proper.

bikeBrain (or simulation) is included in docker-compose.yml and will run when docker-compose up is run

it will post 5000 bikes to db and create 72 dummy users with id:s 1-72 and 72 travelplans (these are not posted to db they are just held in the program)

Rest of bikes gets coordinates 16.0, 59.0

Then the bikeBrain runs and puts bikes in intervals 5s for moving bikes, 10s for non-moving

When a moving bike stops it reverts to reporting it's position to 10s