### PR TITLE
Start bikeBrain separately

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,12 +95,13 @@ services:
 
   bike-brain:
     container_name: bike-brain2
+    tty: true
     build:
       context: ./bikeBrain
       dockerfile: ./Dockerfile.bike
     working_dir: /brain/app
     restart: on-failure
-    command: python3 main.py
+    #command: python3 main.py
     depends_on:
       - "admin-api"
       - "mariadb"


### PR DESCRIPTION
With this PR the bikebrain is started manually by first running docker-compose up --build and then running

docker exec -it bike-brain2 bash

and then:

python3 main.py

in the container